### PR TITLE
protect unescape import from future

### DIFF
--- a/sagenb_export/unescape.py
+++ b/sagenb_export/unescape.py
@@ -1,20 +1,8 @@
 
-
 try:
+    # python 3
+    from html import unescape
+except ImportError:
+    # python 2
     import HTMLParser
-except ImportError:
-    pass
-else:
     unescape = HTMLParser.HTMLParser().unescape
-
-
-try:
-    import html
-except ImportError:
-    pass
-else:
-    unescape = html.unescape
-        
-    
-
-


### PR DESCRIPTION
The future package defines the html module, but it does not have an html.unescape function causing an AttributeError on html.unescape in sage.

This uses `from html import unescape` to get an ImportError on unescape itself, and only performs the Python 2 import if/when the Python 3 import fails.

cc @nthiery
