### PR TITLE
Support XSRF cookie

### DIFF
--- a/sagenb_export/nbextension/www/sagenb-export.js
+++ b/sagenb_export/nbextension/www/sagenb-export.js
@@ -1,5 +1,12 @@
 'use strict';
 
+
+function getCookie(name) {
+    var r = document.cookie.match("\\b" + name + "=([^;]*)\\b");
+    return r ? r[1] : undefined;
+}
+
+
 var exportSageNB = function(uniqueId) {
     console.log('Converting ' + uniqueId);
     var xhttp = new XMLHttpRequest();
@@ -11,5 +18,6 @@ var exportSageNB = function(uniqueId) {
         }
     };
     xhttp.open('POST', '/sagenb/export', true);
+    xhttp.setRequestHeader('X-Xsrftoken', getCookie("_xsrf"));
     xhttp.send(uniqueId);
 };


### PR DESCRIPTION
See http://www.tornadoweb.org/en/stable/guide/security.html#cross-site-request-forgery-protection

This is needed to fix
```
[W 13:39:38.325 NotebookApp] 403 POST /sagenb/export (::1): '_xsrf' argument missing from POST
```