### PR TITLE
Fix aspect ratio of Sage logo

### DIFF
--- a/sagenb_export/nbextension/www/sagenb-export.css
+++ b/sagenb_export/nbextension/www/sagenb-export.css
@@ -32,14 +32,13 @@ p {
 }
 
 .header h1 {
-    flex: 8 1 0;
     margin: auto;
 }
 
 .header img {
-    flex: 2 0 0;
     margin: auto;
     height: 64px;
+    width: 64px;
 }
 
 .warn {


### PR DESCRIPTION
Due to the horizontal flexing of the logo, the aspect ratio is completely messed up on wide windows (at least with Firefox 45.6.0)