### PR TITLE
Skip notebooks from fake "_sage_" user

### DIFF
--- a/sagenb_export/nbextension/list_handler.py
+++ b/sagenb_export/nbextension/list_handler.py
@@ -21,6 +21,10 @@ class ListSageNBHandler(IPythonHandler):
             for notebook in NotebookSageNB.all_iter(dot_sage)
         )
         for key in sorted(notebooks.keys()):
+            # Skip notebooks with owner _sage_ which come from live
+            # documentation and are not real notebooks
+            if key[0] == "_sage_":
+                continue
             yield notebooks[key]
     
     def get(self):


### PR DESCRIPTION
Skip notebooks with owner `_sage_` which come from live documentation and are not real notebooks.